### PR TITLE
Reduce size of return text

### DIFF
--- a/src/mini_rag_runner/light_rag_runner.py
+++ b/src/mini_rag_runner/light_rag_runner.py
@@ -74,7 +74,11 @@ def create_app(working_dir: Path, servers: Optional[List[Dict[str, str]]] = None
             raise RuntimeError("The RAG Context is `None` - should never happen.")
         mode = "hybrid"
         logging.debug(f"Querying for the question: '{question}'.")
-        q_params = QueryParam(mode=mode, only_need_context=True, top_k=top_k)
+        q_params = QueryParam(
+            mode=mode,
+            top_k=top_k,
+            response_type="relevant quotes from original text as bullet points",
+        )
         result = r_context.rag.query(question, param=q_params)
         logging.debug(f"  Result: '{result}'.")
         return [

--- a/src/mini_rag_runner/light_rag_runner.py
+++ b/src/mini_rag_runner/light_rag_runner.py
@@ -78,6 +78,8 @@ def create_app(working_dir: Path, servers: Optional[List[Dict[str, str]]] = None
             mode=mode,
             top_k=top_k,
             response_type="relevant quotes from original text as bullet points",
+            # TODO: as soon as released, update this.
+            # user_prompt="Report only the quotes, don't draw conclusions - that will be done later.",
         )
         result = r_context.rag.query(question, param=q_params)
         logging.debug(f"  Result: '{result}'.")


### PR DESCRIPTION
* Return quotes from the service.
* Prep for the next version of this by adding a system prompt - but commented out. Bug created to get ready for this.

## Notes:

* It is still returning summaries and conclusions, not clear we really want that for this.

Fixes #16